### PR TITLE
fix #24 コーパス読み込み改善

### DIFF
--- a/include/docana/text_file_utility.h
+++ b/include/docana/text_file_utility.h
@@ -33,12 +33,6 @@ public:
     static std::vector<std::vector<std::string>> readCsv(const std::string& file_path);
 
     /**
-     * 文字列リストをCSVファイルに書き込む
-     * @param 書き込む文字列リスト
-     */
-    static void writeCsv(const std::string& file_path, const std::vector<std::vector<std::string>>& values_list);
-
-    /**
      * 文字列を任意の文字で分割する
      * @param str 文字列
      * @param delim 分割する任意の文字

--- a/src/dictionary_generator.cc
+++ b/src/dictionary_generator.cc
@@ -1,35 +1,15 @@
 #include "docana/dictionary_generator.h"
 
-#include <dirent.h>
-
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 #include <map>
 
-#include "docana/document_element.h"
 #include "docana/text_file_utility.h"
 #include "docana/noun_extractor.h"
 #include "docana/vector_utility.h"
 
-class ProgressCounter {
-public:
-    ProgressCounter(int goal) {
-        goal_ = goal;
-    } 
-
-    void count() {
-        std::cout << cnt_ << "/" << goal_ << "\r";
-        cnt_++;
-    }
-    
-    void end() {
-        std::cout << std::endl;
-    }
-private:
-    int goal_;
-    int cnt_ = 0;
-};
 
 bool DictionaryGenerator::generate() {
     // コーパスのパスを読み込む
@@ -40,51 +20,39 @@ bool DictionaryGenerator::generate() {
         return false;
     }
     
-    // コーパスを読み込む
-    std::cout << "Reading corpus..." << std::endl;
-    std::vector<std::string> corpus_texts;
-    ProgressCounter reading_pc(corpus_paths.size());
-    for (std::string corpus_path : corpus_paths) {
-        std::string corpus_text = TextFileUtility::read(corpus_path);
-        if (corpus_text.empty()) {
-            std::cerr << "[WARNING] Corpus file (=\"" << corpus_path << "\") is NULL." << std::endl;    
-        } else {
-            corpus_texts.push_back(corpus_text);
-        }
-        reading_pc.count();
-    }
-    reading_pc.end();
-
-    // コーパスを辞書に変換
+    // コーパスを1ファイルずつ読み込み・変換
     std::cout << "Converting corpus to dictionary..." << std::endl;
     std::map<std::string, int> dict;
-    int corpus_num = corpus_texts.size();
+    int corpus_num = 0;
     int sum_dl = 0;
-    ProgressCounter converting_pc(corpus_num);
-    for (auto corpus_text : corpus_texts) { 
-        NounExtractor ne;
+    NounExtractor ne;
+    for (const auto& corpus_path : corpus_paths) {
+        std::string corpus_text = TextFileUtility::read(corpus_path);
+        if (corpus_text.empty()) {
+            std::cerr << "[WARNING] Corpus file (=\"" << corpus_path << "\") is NULL." << std::endl;
+            continue;
+        }
         std::vector<std::string> raw_corpus_nouns = ne.extractNoun(corpus_text);
-        std::vector<std::string> corpus_nouns = VectorUtility::unique(corpus_nouns);
-        sum_dl += corpus_nouns.size();
-        for (auto corpus_noun : corpus_nouns) {
+        sum_dl += raw_corpus_nouns.size();
+        std::vector<std::string> corpus_nouns = VectorUtility::unique(raw_corpus_nouns);
+        for (const auto& corpus_noun : corpus_nouns) {
             dict[corpus_noun]++;
         }
-        converting_pc.count();
+        corpus_num++;
     }
-    converting_pc.end();
     dict["$corpus_num"] = corpus_num;
     dict["$sum_dl"]     = sum_dl;
 
     // 辞書書き出し
     std::cout << "Write dictionary..." << std::endl;
-    std::vector<std::vector<std::string>> dict_values_list;
-    for (auto item : dict) {
-        std::vector<std::string> dict_values;
-        dict_values.push_back(item.first);
-        dict_values.push_back(std::to_string(item.second));
-        dict_values_list.push_back(dict_values);
+    std::ofstream ofs(dict_path_);
+    if (!ofs) {
+        std::cerr << "[ERROR] Cannot open dictionary file for writing." << std::endl;
+        return false;
     }
-    TextFileUtility::writeCsv(dict_path_, dict_values_list);
+    for (const auto& item : dict) {
+        ofs << item.first << "," << item.second << "\n";
+    }
 
     return true;
 }

--- a/src/text_file_utility.cc
+++ b/src/text_file_utility.cc
@@ -53,21 +53,6 @@ std::vector<std::vector<std::string>> TextFileUtility::readCsv(const std::string
     return values_list;
 }
 
-void TextFileUtility::writeCsv(const std::string& file_path,
-                               const std::vector<std::vector<std::string>>& values_list) {
-    std::string text;
-
-    std::ofstream file(file_path);
-
-    for (auto values : values_list) {
-        for (auto value : values) {
-            file << value << ",";
-        }
-        file << std::endl;
-    }
-
-    file.close();
-}
 
 std::vector<std::string> TextFileUtility::split(const std::string& str, const char delim) {
     std::vector<std::string> values;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,6 +6,7 @@ include(GoogleTest)
 add_executable(unit_test
     cosine_similarity_calculator_test.cc
     vector_utility_test.cc
+    dictionary_generator_test.cc
 )
 target_link_libraries(unit_test docana GTest::GTest GTest::Main)
 include_directories(${PROJECT_SOURCE_DIR}/include ${GTEST_INCLUDE_DIRS})

--- a/test/dictionary_generator_test.cc
+++ b/test/dictionary_generator_test.cc
@@ -1,0 +1,23 @@
+#include <fstream>
+#include <map>
+#include <string>
+
+#include "gtest/gtest.h"
+
+#include "docana/dictionary_generator.h"
+
+namespace {
+
+TEST(DictionaryGeneratorTest, generate) {
+    DictionaryGenerator dg;
+    ASSERT_TRUE(dg.generate());
+}
+
+TEST(DictionaryGeneratorTest, read) {
+    DictionaryGenerator dg;
+    std::map<std::string, int> dict;
+    ASSERT_TRUE(dg.read(&dict));
+    ASSERT_EQ(dict["$corpus_num"], 10);
+}
+
+}  // namespace


### PR DESCRIPTION
## 概要

Issue #24「コーパス読み込み改善」の対応。

## 変更内容

### `src/dictionary_generator.cc`
- ストリーム処理化: 全コーパスをvectorに読み込んでから処理 → 1ファイルずつ読み込み・処理・解放（OOMリスクの解消）
- `NounExtractor` をループ外に移動（毎回生成 → 1回だけ生成、処理速度の改善）
- バグ修正: `VectorUtility::unique(corpus_nouns)` → `VectorUtility::unique(raw_corpus_nouns)`（未初期化変数の参照を修正）
- `sum_dl` の集計をunique後 → unique前（生の単語数）に変更（BM25の `avgdl` 計算値を正しく修正）
- 辞書書き出しの中間 `vector<vector<string>>` を廃止し `ofstream` で直接書き出し（メモリ削減）
- `ProgressCounter` クラスを廃止

### `src/text_file_utility.cc` / `include/docana/text_file_utility.h`
- 不要になった `TextFileUtility::writeCsv` を削除

### `test/dictionary_generator_test.cc`（新規）/ `test/CMakeLists.txt`
- `DictionaryGeneratorTest` を追加（generate / read の2テスト）

## テスト

青空文庫の短編小説10作品をコーパスとして `DictionaryGenerator::generate` を実行し、全テストがパスすることを確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)