### PR TITLE
fix #19 依存性の注入

### DIFF
--- a/include/docana/bm25_vectorizer.h
+++ b/include/docana/bm25_vectorizer.h
@@ -11,6 +11,9 @@
  * Okapi BM25で文書をベクトル化するクラス。
  */
 class Bm25Vectorizer : public Vectorizer {
+public:
+    Bm25Vectorizer(const std::map<std::string, int>& dict, NounExtractor& noun_extractor)
+        : Vectorizer(dict, noun_extractor) {}
 private:
     double calculate(const std::string& term, const size_t term_cnt, const size_t total_term_num) override;
 };

--- a/include/docana/bow_vectorizer.h
+++ b/include/docana/bow_vectorizer.h
@@ -11,6 +11,9 @@
  * Bag of Words (BoW) で文書をベクトル化するクラス。
  */
 class BowVectorizer : public Vectorizer {
+public:
+    BowVectorizer(const std::map<std::string, int>& dict, NounExtractor& noun_extractor)
+        : Vectorizer(dict, noun_extractor) {}
 private:
     double calculate(const std::string& term, const size_t term_cnt, const size_t total_term_num) override;
 };

--- a/include/docana/tfidf_vectorizer.h
+++ b/include/docana/tfidf_vectorizer.h
@@ -11,6 +11,9 @@
  * tf-idfで文書をベクトル化するクラス。
  */
 class TfidfVectorizer : public Vectorizer {
+public:
+    TfidfVectorizer(const std::map<std::string, int>& dict, NounExtractor& noun_extractor)
+        : Vectorizer(dict, noun_extractor) {}
 private:
     double calculate(const std::string& term, const size_t term_cnt, const size_t total_term_num) override;
 };

--- a/include/docana/vectorizer.h
+++ b/include/docana/vectorizer.h
@@ -8,6 +8,7 @@
 #include <map>
 
 #include "document_element.h"
+#include "noun_extractor.h"
 
 /**
  * 文書をベクトル化する抽象クラス。
@@ -15,17 +16,18 @@
 class Vectorizer {
 public:
     virtual ~Vectorizer() = default;
-   
+
     /**
-     * 文書テキストをベクトル化する 
+     * 文書テキストをベクトル化する
      * @param doc_text  文書テキスト
      * @return 文書ベクトル
      */
     std::vector<DocumentElement> vectorize(const std::string& doc_text);
 
 protected:
-    Vectorizer();
+    Vectorizer(const std::map<std::string, int>& dict, NounExtractor& noun_extractor);
     std::map<std::string, int> dict_;
+    NounExtractor& noun_extractor_;
 
     virtual double calculate(const std::string& term, const size_t term_cnt, const size_t total_term_num) = 0;
 };

--- a/include/docana/vectorizer_factory.h
+++ b/include/docana/vectorizer_factory.h
@@ -19,15 +19,16 @@ enum class VectorizerType {
 
 class VectorizerFactory {
 public:
-    // メインの生成メソッド (Enumを受け取る)
-    static std::unique_ptr<Vectorizer> create(VectorizerType type) {
+    static std::unique_ptr<Vectorizer> create(VectorizerType type,
+                                              const std::map<std::string, int>& dict,
+                                              NounExtractor& noun_extractor) {
         switch (type) {
         case VectorizerType::Bow:
-            return std::make_unique<BowVectorizer>();
+            return std::make_unique<BowVectorizer>(dict, noun_extractor);
         case VectorizerType::TfIdf:
-            return std::make_unique<TfidfVectorizer>();
+            return std::make_unique<TfidfVectorizer>(dict, noun_extractor);
         case VectorizerType::Bm25:
-            return std::make_unique<Bm25Vectorizer>();
+            return std::make_unique<Bm25Vectorizer>(dict, noun_extractor);
         default:
             return nullptr;
         }

--- a/samples/sample.cc
+++ b/samples/sample.cc
@@ -6,6 +6,7 @@
 
 #include "docana/document_analyzer.h"
 #include "docana/dictionary_generator.h"
+#include "docana/noun_extractor.h"
 #include "docana/text_file_utility.h"
 #include "docana/vectorizer_factory.h"
 
@@ -17,7 +18,11 @@ public:
 };
 
 void DocanaSample::printTerm(const std::string doc_path) {
-    auto vectorizer = VectorizerFactory::create(VectorizerType::Bm25);
+    std::map<std::string, int> dict;
+    DictionaryGenerator dg;
+    dg.read(&dict);
+    NounExtractor ne;
+    auto vectorizer = VectorizerFactory::create(VectorizerType::Bm25, dict, ne);
     DocumentAnalyzer da(std::move(vectorizer));
 
     std::string doc_text = TextFileUtility::read(doc_path);
@@ -29,7 +34,11 @@ void DocanaSample::printTerm(const std::string doc_path) {
 }
 
 void DocanaSample::printSimilarDocuments(const std::string doc_path) {
-    auto vectorizer = VectorizerFactory::create(VectorizerType::Bm25);
+    std::map<std::string, int> dict;
+    DictionaryGenerator dg;
+    dg.read(&dict);
+    NounExtractor ne;
+    auto vectorizer = VectorizerFactory::create(VectorizerType::Bm25, dict, ne);
     DocumentAnalyzer da(std::move(vectorizer));
 
     std::string doc_text = TextFileUtility::read(doc_path);

--- a/src/vectorizer.cc
+++ b/src/vectorizer.cc
@@ -5,21 +5,16 @@
 #include <iostream>
 
 #include "docana/document_element.h"
-#include "docana/noun_extractor.h"
-#include "docana/dictionary_generator.h"
 #include "docana/vector_utility.h"
 
-Vectorizer::Vectorizer() {
-    DictionaryGenerator dg;
-    dg.read(&dict_);
-}
+Vectorizer::Vectorizer(const std::map<std::string, int>& dict, NounExtractor& noun_extractor)
+    : dict_(dict), noun_extractor_(noun_extractor) {}
 
 std::vector<DocumentElement> Vectorizer::vectorize(const std::string& doc_text) {
     std::vector<DocumentElement> doc_vec;
 
     // 文書から単語を取得
-    NounExtractor ne;
-    std::vector<std::string> doc_terms = ne.extractNoun(doc_text);
+    std::vector<std::string> doc_terms = noun_extractor_.extractNoun(doc_text);
     if (doc_terms.empty()) {
         return doc_vec;
     }


### PR DESCRIPTION
## 概要

Issue #19「依存性の注入」の対応。`Dictionary` と `NounExtractor` を外から注入できるようにしました。

## 変更内容

### `include/docana/vectorizer.h` / `src/vectorizer.cc`
- コンストラクタを `Vectorizer(const std::map<std::string, int>& dict, NounExtractor& noun_extractor)` に変更
- コンストラクタ内の `DictionaryGenerator` 直接生成を廃止
- `vectorize()` 内の `NounExtractor` 直接生成を廃止し、注入されたものを使用

### `include/docana/bm25_vectorizer.h` / `tfidf_vectorizer.h` / `bow_vectorizer.h`
- 各サブクラスにコンストラクタを追加し、基底クラスに転送

### `include/docana/vectorizer_factory.h`
- `create()` に `dict` と `NounExtractor&` を追加

### `samples/sample.cc`
- 呼び出し側で `DictionaryGenerator` で辞書を読み込み、`NounExtractor` を生成して注入する形に変更

## テスト

全4テストがパスすることを確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)