### PR TITLE
fix DictionaryGeneratorTest の実行ディレクトリ問題を修正

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,5 +14,5 @@ add_executable(unit_test
 target_link_libraries(unit_test docana GTest::GTest GTest::Main)
 include_directories(${PROJECT_SOURCE_DIR}/include ${GTEST_INCLUDE_DIRS})
 
-gtest_add_tests(TARGET unit_test)
+gtest_add_tests(TARGET unit_test WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 


### PR DESCRIPTION
ctest が build/ で実行される際に ./dict.csv や ./corpus_paths.txt が 見つからない問題を修正。
gtest_add_tests に WORKING_DIRECTORY を設定し、
テストの実行ディレクトリを test/ ソースディレクトリに変更した。